### PR TITLE
Add ability to register plugins by path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: ./
         with:
           neovim: ${{ matrix.editor == 'neovim' }}
+          plugins: './test/fixtures/hello.vim,test/fixtures/math.vim'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: ./
         with:
           neovim: ${{ matrix.editor == 'neovim' }}
-          plugins: './test/fixtures/hello.vim,test/fixtures/math.vim'
+          plugins: './test/fixtures/*.vim,./'

--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ Running tests with neovim:
     # Installation is easy with the excellent `rhysd/action-setup-vim` action.
     neovim: true
 ```
+
+Registering extra plugins:
+```yml
+- uses: PsychoLlama/vader-action@v1
+  with:
+    # Default: the current repository.
+    plugins: 'path/to/plugin-1,path/to/plugin-2,path/to/plugin-3'
+```

--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ Registering extra plugins:
 - uses: PsychoLlama/vader-action@v1
   with:
     # Default: the current repository.
-    plugins: 'path/to/plugin-1,path/to/plugin-2,path/to/plugin-3'
+    plugins: 'path/to/plugin,other-plugins/*.vim'
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: false
   plugins:
-    description: 'A comma-separated list of plugins to install first.'
+    description: 'A comma-separated list of plugins to install.'
     required: false
     default: $GITHUB_WORKSPACE
 

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,13 @@ inputs:
     required: false
     default: '**/*.vader'
   neovim:
-    description: 'Use neovim instead of vim'
+    description: 'Use neovim instead of vim.'
     required: false
     default: false
+  plugins:
+    description: 'A comma-separated list of plugins to install first.'
+    required: false
+    default: $GITHUB_WORKSPACE
 
 runs:
   using: composite
@@ -25,3 +29,4 @@ runs:
       env:
         TEST_PATTERN: ${{ inputs.test-pattern }}
         USE_NEOVIM: ${{ inputs.neovim }}
+        PLUGIN_PATHS: ${{ inputs.plugins }}

--- a/run-vader
+++ b/run-vader
@@ -6,7 +6,7 @@ vim_runtime_path="$vader_path"
 plugin_post_hooks=
 
 # Dynamically generate the vim runtime path from user input. Typically this is
-# the parent repository, but it could be multiple plugins or plugin globs.
+# the parent repository, but it could be multiple plugins or globs.
 old_ifs="$IFS"; IFS=','
 for plugin in $PLUGIN_PATHS; do
   vim_runtime_path+=",$plugin"

--- a/run-vader
+++ b/run-vader
@@ -3,19 +3,20 @@ set -euo pipefail
 
 vader_path="${GITHUB_ACTION_PATH:-/tmp/}.vader.vim"
 vim_runtime_path="$vader_path"
+plugin_post_hooks=
 
 # Dynamically generate the vim runtime path from user input. Typically this is
 # the parent repository, but it could be multiple plugins or plugin globs.
+old_ifs="$IFS"; IFS=','
 for plugin in $PLUGIN_PATHS; do
   vim_runtime_path+=",$plugin"
-done
 
-# Obligatory check for "/after" plugins (see `:help after-directory`)
-for plugin in $PLUGIN_PATHS; do
+  # Obligatory check for "/after" plugins (see `:help after-directory`)
   if [[ -d "$plugin/after" ]]; then
-    vim_runtime_path+=",$plugin/after"
+    plugin_post_hooks+=",$plugin/after"
   fi
 done
+IFS="$old_ifs"
 
 # For local testing: don't try to clone the repo twice.
 if [[ ! -d "$vader_path" ]]; then
@@ -24,7 +25,7 @@ fi
 
 vimrc="
 filetype off
-set runtimepath+=$vim_runtime_path
+set runtimepath+=${vim_runtime_path}${plugin_post_hooks}
 filetype plugin indent on
 "
 

--- a/run-vader
+++ b/run-vader
@@ -2,7 +2,20 @@
 set -euo pipefail
 
 vader_path="${GITHUB_ACTION_PATH:-/tmp/}.vader.vim"
-plugin_path="${GITHUB_WORKSPACE:-.}"
+vim_runtime_path="$vader_path"
+
+# Dynamically generate the vim runtime path from user input. Typically this is
+# the parent repository, but it could be multiple plugins or plugin globs.
+for plugin in $PLUGIN_PATHS; do
+  vim_runtime_path+=",$plugin"
+done
+
+# Obligatory check for "/after" plugins (see `:help after-directory`)
+for plugin in $PLUGIN_PATHS; do
+  if [[ -d "$plugin/after" ]]; then
+    vim_runtime_path+=",$plugin/after"
+  fi
+done
 
 # For local testing: don't try to clone the repo twice.
 if [[ ! -d "$vader_path" ]]; then
@@ -11,58 +24,7 @@ fi
 
 vimrc="
 filetype off
-set rtp+=$vader_path
-
-$(echo -n "${PLUGIN_PATHS:-}" | awk '
-# Progressively build out a runtime path for vim.
-function append_plugin(plugin_file_path) {
-  if (system("test -d " plugin_file_path) != 0) {
-    print "Error: not a directory: " plugin_file_path >> "/dev/stderr"
-    close("/dev/stderr")
-    abort = 1
-  }
-
-  if (length(runtime_path) > 0) {
-    runtime_path = runtime_path ","
-  }
-
-  runtime_path = runtime_path plugin_file_path
-  plugins[plugin_index++] = plugin_file_path
-  has_plugins = 1
-}
-
-BEGIN {
-  RS="," # Split file paths by comma.
-  runtime_path = ""
-  plugin_index = 0
-  has_plugins = 0
-  abort = 0
-}
-
-{
-  append_plugin($0)
-}
-
-END {
-  if (abort) {
-    exit 1
-  }
-
-  for (idx in plugins) {
-    plugin_after_hook = plugins[idx] "/after"
-
-    if (system("test -d " plugin_after_hook) == 0) {
-      append_plugin(plugin_after_hook)
-    }
-  }
-
-  # Output a vim command to update the plugin path.
-  if (has_plugins) {
-    print "set runtimepath+=" runtime_path
-  }
-}
-')
-
+set runtimepath+=$vim_runtime_path
 filetype plugin indent on
 "
 

--- a/run-vader
+++ b/run-vader
@@ -19,6 +19,8 @@ if [[ ! "$USE_NEOVIM" == false ]]; then
   editor=nvim
 fi
 
+echo "Paths: ${PLUGIN_PATHS[*]}"
+
 # Running in silent Ex mode avoids garbled log output.
 # Unfortunately color isn't supported without an interactive vim frontend.
 "$editor" -Es -Nu <(echo "$vimrc") -c "Vader! $TEST_PATTERN"

--- a/run-vader
+++ b/run-vader
@@ -1,25 +1,75 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-vader_path="${GITHUB_ACTION_PATH}.vader.vim"
-plugin_path="$GITHUB_WORKSPACE"
+vader_path="${GITHUB_ACTION_PATH:-/tmp/}.vader.vim"
+plugin_path="${GITHUB_WORKSPACE:-.}"
 
-git clone --depth=1 'https://github.com/junegunn/vader.vim.git' "$vader_path"
+# For local testing: don't try to clone the repo twice.
+if [[ ! -d "$vader_path" ]]; then
+  git clone --depth=1 'https://github.com/junegunn/vader.vim.git' "$vader_path"
+fi
 
 vimrc="
 filetype off
 set rtp+=$vader_path
-set rtp+=$plugin_path
-set rtp+=$plugin_path/after
+
+$(echo -n "${PLUGIN_PATHS:-}" | awk '
+# Progressively build out a runtime path for vim.
+function append_plugin(plugin_file_path) {
+  if (system("test -d " plugin_file_path) != 0) {
+    print "Error: not a directory: " plugin_file_path >> "/dev/stderr"
+    close("/dev/stderr")
+    abort = 1
+  }
+
+  if (length(runtime_path) > 0) {
+    runtime_path = runtime_path ","
+  }
+
+  runtime_path = runtime_path plugin_file_path
+  plugins[plugin_index++] = plugin_file_path
+  has_plugins = 1
+}
+
+BEGIN {
+  RS="," # Split file paths by comma.
+  runtime_path = ""
+  plugin_index = 0
+  has_plugins = 0
+  abort = 0
+}
+
+{
+  append_plugin($0)
+}
+
+END {
+  if (abort) {
+    exit 1
+  }
+
+  for (idx in plugins) {
+    plugin_after_hook = plugins[idx] "/after"
+
+    if (system("test -d " plugin_after_hook) == 0) {
+      append_plugin(plugin_after_hook)
+    }
+  }
+
+  # Output a vim command to update the plugin path.
+  if (has_plugins) {
+    print "set runtimepath+=" runtime_path
+  }
+}
+')
+
 filetype plugin indent on
 "
 
 editor=vim
-if [[ ! "$USE_NEOVIM" == false ]]; then
+if [[ ! "${USE_NEOVIM:-}" == false ]]; then
   editor=nvim
 fi
-
-echo "Paths: ${PLUGIN_PATHS[*]}"
 
 # Running in silent Ex mode avoids garbled log output.
 # Unfortunately color isn't supported without an interactive vim frontend.

--- a/test/fixtures/hello.vim/autoload/hello.vim
+++ b/test/fixtures/hello.vim/autoload/hello.vim
@@ -1,0 +1,4 @@
+" Only used for testing.
+func! hello#() abort
+  return 'Plugin loaded'
+endfunc

--- a/test/fixtures/math.vim/after/plugin/math.vim
+++ b/test/fixtures/math.vim/after/plugin/math.vim
@@ -1,0 +1,2 @@
+" Used to detect support for /after in unit tests.
+let g:loaded_post_plugins = v:true

--- a/test/fixtures/math.vim/autoload/math.vim
+++ b/test/fixtures/math.vim/autoload/math.vim
@@ -1,0 +1,4 @@
+" Only used for testing.
+func! math#sum(x, y) abort
+  return a:x + a:y
+endfunc

--- a/test/plugins.vader
+++ b/test/plugins.vader
@@ -1,3 +1,6 @@
 Execute (ensure plugins loaded):
-  AssertEqual 'Plugin loaded', hello#()
-  AssertEqual 5, math#sum(2, 3)
+  AssertEqual hello#(), 'Plugin loaded'
+  AssertEqual math#sum(2, 3), 5
+
+Execute (ensure post plugins loaded):
+  AssertEqual has_key(g:, 'loaded_post_plugins'), 1

--- a/test/plugins.vader
+++ b/test/plugins.vader
@@ -1,0 +1,3 @@
+Execute (ensure plugins loaded):
+  AssertEqual 'Plugin loaded', hello#()
+  AssertEqual 5, math#sum(2, 3)


### PR DESCRIPTION
This is useful for monorepos or plugins that are hidden in a folders. I'm hitting this limitation with [vim-plugin-nursery](https://github.com/PsychoLlama/vim-plugin-nursery/).